### PR TITLE
move create timing

### DIFF
--- a/packages/enty/src/ArraySchema.js
+++ b/packages/enty/src/ArraySchema.js
@@ -23,19 +23,15 @@ export default class ArraySchema<A: Schema> implements StructuralSchemaInterface
         this.create = options.create || (aa => aa);
     }
 
-    normalize(data: mixed, entities: Object = {}): NormalizeState {
+    normalize(data: any, entities: Object = {}): NormalizeState {
         let schemas = {};
-        const result = this.create(data)
-            .map((item: any): any => {
-                const {result, schemas: childSchemas} = this.shape.normalize(item, entities);
+        const result = data.map((item: any): any => {
+            const {result, schemas: childSchemas} = this.shape.normalize(item, entities);
+            Object.assign(schemas, childSchemas);
+            return result;
+        });
 
-                // add child schemas to the schema collection
-                Object.assign(schemas, childSchemas);
-
-                return result;
-            });
-
-        return {entities, schemas, result};
+        return {entities, schemas, result: this.create(result)};
     }
 
     denormalize(denormalizeState: DenormalizeState, path: Array<*> = []): any {

--- a/packages/enty/src/ObjectSchema.js
+++ b/packages/enty/src/ObjectSchema.js
@@ -30,7 +30,7 @@ export default class ObjectSchema<A: {}> implements StructuralSchemaInterface<A>
      */
     normalize(data: mixed, entities: Object = {}): NormalizeState {
         const {shape} = this;
-        const dataMap = this.create(data);
+        const dataMap = data;
         let schemas = {};
 
         const result = Object.keys(shape)
@@ -46,7 +46,7 @@ export default class ObjectSchema<A: {}> implements StructuralSchemaInterface<A>
                 return result;
             }, dataMap);
 
-        return {entities, schemas, result};
+        return {entities, schemas, result: this.create(result)};
 
     }
 


### PR DESCRIPTION
blueflag-record's default values cant handle the way enty traverses the
object tree. Enty can be nice and sidestep this problem by being lazy in the way
it calls create, waiting till after the normalize happens.