### PR TITLE
Add results parameter to EntityApi factory to provide initial results

### DIFF
--- a/packages/react-enty/src/EntityApi.js
+++ b/packages/react-enty/src/EntityApi.js
@@ -14,9 +14,9 @@ type ActionMap = {
 };
 
 
-export default function EntityApi(actionMap: ActionMap, schema?: Schema): Object {
+export default function EntityApi(actionMap: ActionMap, schema?: Schema, results?: Array<{key: string, payload: any}>): Object {
 
-    const {Provider, ProviderHoc, Context} = ProviderFactory({schema});
+    const {Provider, ProviderHoc, Context} = ProviderFactory({schema, results});
 
     let api = EntityApiFactory(
         actionMap,


### PR DESCRIPTION
Each item in the results array is treated as a successful response from
the api and is normalized into the initial state with a successful
request state. This allows the store to be primed with data on the
server side and let react views render synchronously.

It wont prevent loading states if not enough data is given to the views,
but worst case it will render a loader to the output.