### PR TITLE
Let priming data choose which action type to prime with

### DIFF
--- a/packages/react-enty/src/EntityApi.js
+++ b/packages/react-enty/src/EntityApi.js
@@ -1,5 +1,6 @@
 //@flow
 import type {Schema} from 'enty/lib/util/definitions';
+import type {ProviderConfig} from './ProviderFactory';
 
 import EntityApiFactory from 'enty-state/lib/EntityApiFactory';
 import ProviderFactory from './ProviderFactory';
@@ -14,7 +15,7 @@ type ActionMap = {
 };
 
 
-export default function EntityApi(actionMap: ActionMap, schema?: Schema, results?: Array<{responseKey: string, payload: any}>): Object {
+export default function EntityApi(actionMap: ActionMap, schema?: Schema, results?: $PropertyType<ProviderConfig, 'results'>): Object {
 
     const {Provider, ProviderHoc, Context} = ProviderFactory({schema, results});
 

--- a/packages/react-enty/src/ProviderFactory.js
+++ b/packages/react-enty/src/ProviderFactory.js
@@ -9,9 +9,13 @@ import LoggingReducer from 'enty-state/lib/util/LoggingReducer';
 import type {Action} from 'enty-state/lib/util/definitions';
 import type {Schema} from 'enty/lib/util/definitions';
 
-type ProviderConfig = {
+export type ProviderConfig = {
     schema?: Schema,
-    results?: Array<{responseKey: string, payload: any}>
+    results?: Array<{
+        responseKey: string,
+        payload: any,
+        type?: 'ENTY_RECEIVE' | 'ENTY_ERROR' | 'ENTY_FETCH'
+    }>
 };
 
 type ProviderFactoryReturn = {
@@ -57,7 +61,7 @@ export default function ProviderFactory(config: ProviderConfig): ProviderFactory
 
             const intialValue = [
                 {type: 'ENTY_INIT', payload: null, meta: {responseKey: 'Unknown'}},
-                ...results.map(({responseKey, payload}) => ({type: 'ENTY_RECEIVE', payload, meta: {responseKey}}))
+                ...results.map(({responseKey, payload, type = 'ENTY_RECEIVE'}) => ({type, payload, meta: {responseKey}}))
 
             ].reduce(reducer, firstState);
 

--- a/packages/react-enty/src/__tests__/ProviderFactory-test.js
+++ b/packages/react-enty/src/__tests__/ProviderFactory-test.js
@@ -77,6 +77,26 @@ describe('Component', () => {
         expect(state.response.b.bar).toBe('bar1');
         expect(state.entities.bar.bar1.name).toBe('barrr');
     });
+
+    it('will apply types of initial actions', () => {
+        const foo = new EntitySchema('foo');
+        const schema = new ObjectSchema({foo});
+        const results = [
+            {type: 'ENTY_ERROR', responseKey: 'a', payload: {foo: {id: 'foo1', name: 'foooo'}}}
+        ];
+        const {Provider, Context} = ProviderFactory({schema, results});
+
+        const [state] = getContext((Child) => () => {
+            return <Provider>
+                <Context.Consumer
+                    children={(context) => <Child context={context}/>}
+                />
+            </Provider>;
+        });
+
+        expect(state.requestState.a.isError).toBe(true);
+        expect(state.requestState.a.isSuccess).toBeUndefined();
+    });
 });
 
 describe('Hoc', () => {


### PR DESCRIPTION
```js
EntityApi({}, schema, [type: 'ENTY_ERROR', responseKey: 'foo', payload: 123])
```